### PR TITLE
Add simple MTP log copy script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,23 @@
 # get-my-flight-logs
-A command line python application that uses the MTP protocol to copy flight log files from a DJI Remote Control
+
+This is a command line Python application that copies flight log files from a DJI Remote Control using the MTP protocol.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a `config.toml` file specifying the source path on the device and the local destination directory:
+   ```toml
+   [paths]
+   source = "/sdcard/DJI/dji.go.v4/FlightRecord"
+   destination = "./flightlogs"
+   ```
+3. Run the script:
+   ```bash
+   python getmyflightlogs.py --help
+   python getmyflightlogs.py
+   ```
+
+The script connects to the first available MTP device and copies all files from the configured source path into the destination directory.

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,3 @@
+[paths]
+source = "/sdcard/DJI/dji.go.v4/FlightRecord"
+destination = "./flightlogs"

--- a/getmyflightlogs.py
+++ b/getmyflightlogs.py
@@ -1,0 +1,67 @@
+import argparse
+import os
+import sys
+from typing import Optional
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # fallback for Python < 3.11
+    import tomli as tomllib
+
+
+class Config:
+    def __init__(self, source: str, destination: str) -> None:
+        self.source = source
+        self.destination = destination
+
+
+def load_config(path: str) -> Config:
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    paths = data.get("paths", {})
+    source = paths.get("source")
+    destination = paths.get("destination")
+    if not source or not destination:
+        raise ValueError("Config must define paths.source and paths.destination")
+    return Config(source, destination)
+
+
+def copy_logs(config: Config) -> None:
+    import pymtp
+
+    device = pymtp.MTP()
+    device.connect()
+    try:
+        os.makedirs(config.destination, exist_ok=True)
+        for obj in device.get_ObjectHandles():
+            info = device.get_ObjectInfo(obj)
+            if info.filename.startswith(config.source):
+                data = device.get_file_to_buffer(obj)
+                dest_path = os.path.join(
+                    config.destination, os.path.basename(info.filename)
+                )
+                with open(dest_path, "wb") as f:
+                    f.write(data)
+    finally:
+        device.disconnect()
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Copy DJI flight logs via MTP")
+    parser.add_argument(
+        "-c",
+        "--config",
+        default="config.toml",
+        help="Path to configuration file",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+    config = load_config(args.config)
+    copy_logs(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pymtp
+tomli
+black


### PR DESCRIPTION
## Summary
- add a small CLI to copy flight logs using PyMTP
- provide sample `config.toml` file
- document usage in README
- add requirements list

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile getmyflightlogs.py`
- `python getmyflightlogs.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688648f1598c832dbec1b380aad0d9e1