### PR TITLE
Add CLI options for source and destination

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,36 @@
+# Byte-code files
+*.pyc
+__pycache__/
+.pytest_cache/
+
+# Virtual environments
+venv/
+.venv/
+env/
+.env/
+
+# Editor/IDE specific files
+.idea/
+.vscode/
+*.swp
+*.bak
+*.swo
+
+# Operating System files
+.DS_Store
+Thumbs.db
+
+# Build artifacts
+dist/
+build/
+*.egg-info/
+.coverage
+
+# Log files
+*.log
+
+# Database files
+*.sqlite3
+
+# Environment variables
+.env

--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # get-my-flight-logs
-A command line python application that uses the MTP protocol to copy flight log files from a DJI Remote Control
+
+This is a command line Python application that copies flight log files from a DJI Remote Control using the MTP protocol.
+
+## Usage
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the script:
+   ```bash
+   python getmyflightlogs.py --help
+   python getmyflightlogs.py
+   ```
+   Use `--source` to set the path on the device and `--destination` for the local
+   folder. The defaults are `/sdcard/DJI/dji.go.v4/FlightRecord` and `./flightlogs`.
+
+The script connects to the first available MTP device and copies all files from
+the source path into the destination directory.

--- a/getmyflightlogs.py
+++ b/getmyflightlogs.py
@@ -1,0 +1,47 @@
+import argparse
+import os
+from typing import Optional
+
+DEFAULT_SOURCE = "/sdcard/DJI/dji.go.v4/FlightRecord"
+DEFAULT_DESTINATION = "./flightlogs"
+
+
+def copy_logs(source: str, destination: str) -> None:
+    import pymtp
+
+    device = pymtp.MTP()
+    device.connect()
+    try:
+        os.makedirs(destination, exist_ok=True)
+        for obj in device.get_ObjectHandles():
+            info = device.get_ObjectInfo(obj)
+            if info.filename.startswith(source):
+                data = device.get_file_to_buffer(obj)
+                dest_path = os.path.join(destination, os.path.basename(info.filename))
+                with open(dest_path, "wb") as f:
+                    f.write(data)
+    finally:
+        device.disconnect()
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Copy DJI flight logs via MTP")
+    parser.add_argument(
+        "-s", "--source", default=DEFAULT_SOURCE, help="Source path on the device"
+    )
+    parser.add_argument(
+        "-d",
+        "--destination",
+        default=DEFAULT_DESTINATION,
+        help="Destination directory",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> None:
+    args = parse_args(argv)
+    copy_logs(args.source, args.destination)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pymtp
+black


### PR DESCRIPTION
## Summary
- remove `config.toml` and toml dependency
- add default source and destination constants
- support `--source` and `--destination` CLI options
- update usage instructions

## Testing
- `pip install -r requirements.txt -q`
- `python -m py_compile getmyflightlogs.py`
- `python getmyflightlogs.py --help`


------
https://chatgpt.com/codex/tasks/task_e_688648f1598c832dbec1b380aad0d9e1